### PR TITLE
BUGFIX: make links relative so they resolve correctly

### DIFF
--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -36,12 +36,12 @@ location then you can register paths directly:
 
 
 To configure the documentation system the configuration information is 
-available on the [Configurations](dev/docs/en/docsviewer/configuration-options)
+available on the [Configurations](configuration-options)
 page.
 
 ## Writing documentation
 
-See [Writing Documentation](dev/docs/en/sapphiredocs/writing-documentation) 
+See [Writing Documentation](writing-documentation)
 for more information on how to write markdown files which are available here. 
 
 


### PR DESCRIPTION
Links had been relative to the document root and threw error 404.
In addition, that hard-coded the dev/docs path into the documentation.

This could also be back-ported to the 0.1 branch for 2.4 compatibility.
