### PR TITLE
NEW Enable using the site root for documentation

### DIFF
--- a/code/DocumentationService.php
+++ b/code/DocumentationService.php
@@ -87,6 +87,15 @@ class DocumentationService {
 	}
 	
 	/**
+	 * Return the language_mapping
+	 *
+	 * @return array
+	 */
+	public static function get_language_mapping() {
+		return self::$language_mapping;
+	}	
+	
+	/**
 	 * Check to see if a given extension is a valid extension to be rendered.
 	 * Assumes that $ext has a leading dot as that is what $valid_extension uses.
 	 *

--- a/code/controllers/DocumentationViewer.php
+++ b/code/controllers/DocumentationViewer.php
@@ -164,12 +164,21 @@ class DocumentationViewer extends Controller {
 		if(!$request->isGET() || isset($_GET['action_results'])) {
 			return parent::handleRequest($request, $model);
 		}
+		$languages = DocumentationService::get_language_mapping();
+		$action = $request->param('Action');
+		if (empty($action) || array_key_exists($action, $languages)) { 
 
-		$firstParam = ($request->param('Action')) ? $request->param('Action') : $request->shift();		
-		$secondParam = $request->shift();
+			$firstParam = 'home'; 
+			$secondParam = $request->param('Action');
+		}
+		else {
+			$firstParam = $request->param('Action');
+			$secondParam = $request->shift();
+		}
+
 		$thirdParam = $request->shift();
 		
-		$this->Remaining = $request->shift(10);
+		$this->Remaining = $request->shift(10);		
 		
 		// if no params passed at all then it's the homepage
 		if(!$firstParam && !$secondParam && !$thirdParam) {
@@ -356,7 +365,7 @@ class DocumentationViewer extends Controller {
 				)));
 			}
 		}
-		
+
 		return $output;
 	}
 	
@@ -737,10 +746,11 @@ class DocumentationViewer extends Controller {
 		$objEntity = $this->getEntity();
 		if ($objEntity && $objEntity->getStableVersion() == $version) $version = '';
 
+		$name = ($entity == 'home')? '': $entity;
 		$link = Controller::join_links(
 			Director::absoluteBaseURL(), 
 			self::get_link_base(), 
-			$entity, 
+			$name, 
 			($entity) ? $lang : "", // only include lang for entity - sapphire/en vs en/
 			($entity) ? $version :"",
 			$action
@@ -748,7 +758,7 @@ class DocumentationViewer extends Controller {
 
 		return $link;
 	} 
-	
+
 	/**
 	 * Build the language dropdown.
 	 *

--- a/code/models/DocumentationEntity.php
+++ b/code/models/DocumentationEntity.php
@@ -258,9 +258,10 @@ class DocumentationEntity extends ViewableData {
 		if(!$lang) $lang = 'en';
 		if($version == $this->getStableVersion()) $version = false;
 		
+		$folder = ($folder = $this->getFolder() && 'home' == $folder)? '': $folder;
 		return Controller::join_links(
 			DocumentationViewer::get_link_base(), 
-			$this->getFolder(),
+			$folder,
 			$lang,
 			$version
 		);

--- a/docs/en/Configuration-Options.md
+++ b/docs/en/Configuration-Options.md
@@ -53,6 +53,36 @@ to new structures.
 		'templates' => 'sapphire/en/topics/templates'
 	));
 	
-	
+## Documentation in your site root
 
+If you want to register a modules documentation in your site root, use 'home' as the name of your registration. Using the docsviewer docs as an example, add the following settings in _config.php:
+
+	:::php
+	DocumentationService::set_automatic_registration(false);
+
+	DocumentationViewer::set_link_base('');
+
+	try {   
+		DocumentationService::register(
+			$name = 'home', 
+			$path = BASE_PATH . '/docsviewer/docs/', 
+			$version = '3.1',
+			$title = 'Great Documentation',
+			$latest = true
+		);
+	} catch(InvalidArgumentException $e) {
+	}
+
+Next you need to set up the rules in your _config/routes.yml, replacing the default rules from the framework/_config/routes.yml:
+
+	---
+	Name: docs
+	After: framework/routes#adminroutes
+	---
+	Director:
+	  rules:
+	    '$Action': 'DocumentationViewer'    
+	    '': 'DocumentationViewer'
+	    'DocumentationOpenSearchController//$Action': 'DocumentationOpenSearchController'
 	
+**Note**: You'll be able to reach the admin section, but using /dev/ will not (yet) work with these settings...


### PR DESCRIPTION
Selecting 'home' as the name for the registration enables using the
site root as startingpoint for the documentation of one single module
(multiple versions)

Note: need to add settings to _config.php and adapt the rules in _confi/routes.yml. Documented in docs/en/Configuration-Options.md
