### PR TITLE
MAJOR: enable the use of custom metadata and page sorting

### DIFF
--- a/code/DocumentationParser.php
+++ b/code/DocumentationParser.php
@@ -44,7 +44,7 @@ class DocumentationParser {
 	public static function parse(DocumentationPage $page, $baselink = null) {
 		if(!$page || (!$page instanceof DocumentationPage)) return false;
 
-		$md = $page->getMarkdown();
+		$md = $page->getMarkdown(true);
 		
 		// Pre-processing
 		$md = self::rewrite_image_links($md, $page);

--- a/code/DocumentationService.php
+++ b/code/DocumentationService.php
@@ -178,7 +178,7 @@ class DocumentationService {
 	 * @param bool $allow
 	 */
 	public static function enable_meta_comments($allow = true) {
-		self::$meta_comments_enabled = ($allow)? true: false;
+		self::$meta_comments_enabled = (bool) $allow;
 	} 
 	
 	/**

--- a/docs/en/Configuration-Options.md
+++ b/docs/en/Configuration-Options.md
@@ -63,12 +63,7 @@ Custom metadata can be added to the head of the MarkDown file like this:
 	
 
 Make sure to add an empty line to separate the metadata from the content of
-the file. To make the metadata invisible on the page, you can use a comment tag:
-
-	<!--
-	pagenumber: 1
-	title: A custom title
-	-->
+the file. 
 
 You now need to explicitly enable the use of metadata by adding the following to 
 your _config.php:


### PR DESCRIPTION
This version is based on the current master, all commits squashed. It enables the use of metadata to set a custom pagenumber and (menu)title. metadata can optionally be surrounded by a comment tag to make them invisible on the page. 
