### PR TITLE
Fix/support dash in relative links

### DIFF
--- a/code/DocumentationParser.php
+++ b/code/DocumentationParser.php
@@ -388,7 +388,7 @@ class DocumentationParser {
 				
 				// Resolve relative paths
 				while(strpos($relativeUrl, '..') !== FALSE) {
-					$relativeUrl = preg_replace('/\w+\/\.\.\//', '', $relativeUrl);
+					$relativeUrl = preg_replace('/[-\w]+\/\.\.\//', '', $relativeUrl);
 				}
 			
 				// Replace any double slashes (apart from protocol)


### PR DESCRIPTION
Currently if you go had something like this: `[Some Link](../)`
and you were in `http://devsite.dev/dev/docs/my_module/en/server-setup/location-specific/`

The parser will resolve the link as: `http://devsite.dev/dev/docs/my_module/en/server-setup/location-`

This is because the regex is only matching _Any word character (letter, number, underscore)_. I've added the dash.
