### PR TITLE
FIX: Fixed encoding of & in OpenSearchDescription URLs.

### DIFF
--- a/code/controllers/DocumentationOpenSearchController.php
+++ b/code/controllers/DocumentationOpenSearchController.php
@@ -27,10 +27,10 @@ class DocumentationOpenSearchController extends Controller {
 		$link = Director::absoluteBaseUrl() .
 		$data['SearchPageLink'] = Controller::join_links(
 			$viewer->Link(),
-			'results/?Search={searchTerms}&amp;start={startIndex}&amp;length={count}&amp;action_results=1'
+			'results/?Search={searchTerms}&start={startIndex}&length={count}&action_results=1'
 		);
 		
-		$data['SearchPageAtom'] = $data['SearchPageLink'] . '&amp;format=atom';
+		$data['SearchPageAtom'] = $data['SearchPageLink'] . '&format=atom';
 		
 		return $this->customise(
 			new ArrayData($data)

--- a/templates/OpenSearchDescription.ss
+++ b/templates/OpenSearchDescription.ss
@@ -6,7 +6,7 @@
 	<% if Tags %><Tags>$Tags</Tags><% end_if %>
 	<% if Contact %><Contact>$Content</Contact><% end_if %>
   	
-	<% if SearchPageLink %><Url type="text/html" template="$SearchPageLink"></Url><% end_if %>
-	<% if SearchPageAtom %><Url type="application/atom+xml" template="$SearchPageAtom"></Url><% end_if %>
-	<% if SearchPageJson %><Url type="application/x-suggestions+json" template="$SearchPageJson"></Url><% end_if %>
+	<% if SearchPageLink %><Url type="text/html" template="$SearchPageLink.XML"></Url><% end_if %>
+	<% if SearchPageAtom %><Url type="application/atom+xml" template="$SearchPageAtom.XML"></Url><% end_if %>
+	<% if SearchPageJson %><Url type="application/x-suggestions+json" template="$SearchPageJson.XML"></Url><% end_if %>
 </OpenSearchDescription>


### PR DESCRIPTION
Without this fix, the &amp; was then passed to urlencode(), which escaped the ; and make invalid
XML.  This keeps XML out of the source URL (so the & is just a raw & in the code) and relies on
the template engine to escape XML as needed (the .XML on the end of the variables).
