### PR TITLE
Regex change to support combo of tab & space in md

### DIFF
--- a/code/DocumentationParser.php
+++ b/code/DocumentationParser.php
@@ -96,7 +96,7 @@ class DocumentationParser {
 					$inner = true;
 				}
 			} 
-			elseif(preg_match('/^\t(.*)/', $line, $matches)) {
+			elseif(preg_match('/^[\ ]{0,3}?[\t](.*)/', $line, $matches)) {
 				// inner line of block, or first line of standard markdown code block
 				// regex removes first tab (any following tabs are part of the code).
 				$output[$i] = ($started) ? '' : '<pre>' . "\n";


### PR DESCRIPTION
Fix to parser to account for mixture of tabs & spaces. This should be fixed in the documentation markdown as well, but at least this will present the occurrence of both gracefully.

Here is an example of what I mean:

http://doc.silverstripe.com/framework/en/3.0/topics/testing#running-tests
