### PR TITLE
Fixing text highlight css

### DIFF
--- a/css/typography.css
+++ b/css/typography.css
@@ -1,10 +1,14 @@
 /*! text selection */
 ::-moz-selection {	
 	text-shadow:none;
+	color: #ffffff;
+	background: #1389CE;
 }
 
 ::selection { 	
 	text-shadow: none;
+	color: #ffffff;
+	background: #1389CE;
 }
 
 /*! links */


### PR DESCRIPTION
By setting anything to ::selection in the css it resets all selection styling. Meaning highlighted text does not show any indication of highlighting. 

I have added in the selection color and background so text appears highlighted when selected.
