### PR TITLE
Pass the current version to the search

### DIFF
--- a/code/forms/DocumentationSearchForm.php
+++ b/code/forms/DocumentationSearchForm.php
@@ -3,18 +3,25 @@
 class DocumentationSearchForm extends Form {
 
 	public function __construct($controller) {
-		$versions = HiddenField::create(
-			'Versions',
-			_t('DocumentationViewer.VERSIONS', 'Versions'), 
-			implode(',', $controller->getManifest()->getAllVersions())
-		);
+
 
 		$fields = new FieldList(
 			TextField::create('q', _t('DocumentationViewer.SEARCH', 'Search'), '')
-				->setAttribute('placeholder', _t('DocumentationViewer.SEARCH', 'Search')),
-			$versions
+				->setAttribute('placeholder', _t('DocumentationViewer.SEARCH', 'Search'))
 		);
-		
+
+		$page = $controller->getPage();
+
+		if($page){
+			$versions = HiddenField::create(
+				'Versions',
+				_t('DocumentationViewer.VERSIONS', 'Versions'),
+				$page->getEntity()->getVersion()
+			);
+
+			$fields->push($versions);
+		}
+
 		$actions = new FieldList(
 			new FormAction('results', _t('DocumentationViewer.SEARCH', 'Search'))
 		);
@@ -24,7 +31,7 @@ class DocumentationSearchForm extends Form {
 		$this->disableSecurityToken();
 		$this->setFormMethod('GET');
 		$this->setFormAction($controller->Link('results'));
-		
+
 		$this->addExtraClass('search');
 	}
 }


### PR DESCRIPTION
From a UX POV, when I'm searching docs I'm likely to be working on a site of a specific version - results of docs from older or newer versions are likely to be less relevant to me. 

If I want to search wider after my initial search I can use the check boxes on the advanced search.

I feel it's a reasonable assumption that a search when I'm on a specific version should return results from that version only.