### PR TITLE
FIX hint styling

### DIFF
--- a/css/layout.css
+++ b/css/layout.css
@@ -474,7 +474,8 @@ html {
 	color:#666;
 }
 
-.info {	
+.info,
+.hint {	
 	background: rgb(184, 229, 250);
 }
 


### PR DESCRIPTION
All info boxes in docs that use the 'hint' css class as recommended are currently missing a coloured background.

![pasted_image_15_06_2015_9_50_am](https://cloud.githubusercontent.com/assets/1079425/8166054/32889bce-134a-11e5-90a0-aad25a785d9b.png)