### PR TITLE
Fixing issue where anchor idicator does not show on hover

### DIFF
--- a/css/typography.css
+++ b/css/typography.css
@@ -191,11 +191,9 @@ h6 .heading-anchor-link {
 	h3.hover .heading-anchor-link,
 	h4.hover .heading-anchor-link,
 	h5.hover .heading-anchor-link,
-	h6.hover .heading-anchor-link {
-		display: inline;
-	}
-	
+	h6.hover .heading-anchor-link,
 	.heading-anchor-link:hover {
+		display: inline;
 		color: #aaa;
 	}
 


### PR DESCRIPTION
If you hover on the headers at the moment, the anchor indicator doesn't show unless you hover on where it is, which isn't very discoverable.

This fixes that problem