### PR TITLE
Confirm docsviewer works with silverstripe 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
 		"irc": "irc://irc.freenode.org/silverstripe"
 	}],
 	"require": {
-		"silverstripe/framework": "~3.1",
+		"silverstripe/framework": "~3.1,~4.0",
 		"erusev/parsedown-extra": "0.2.2",
 		"erusev/parsedown": "~1.1.0"
 	},


### PR DESCRIPTION
I've done some basic confirmation that docsviewer works with
SilverStripe 4, at least as it stands in the current master branch.

Making this change means that docsviewer be checked into ss4 projects,
so that documentation updates can be tested.

One caveat: it's likely that changes to classnames, etc, will be needed before ss4
is released. Would it be appropriate to create a 1.0 branch now and alias master
to 2.0.x-dev? That means that 1.0 can be kept as the 3.x compatible version.
