### PR TITLE
Add a way to check if a version is the current stable

### DIFF
--- a/code/DocumentationManifest.php
+++ b/code/DocumentationManifest.php
@@ -709,7 +709,8 @@ class DocumentationManifest {
 					$output->push(new ArrayData(array(
 						'Title' => $check->getVersion(),
 						'Link' => $check->Link(),
-						'LinkingMode' => ($same) ? 'current' : 'link'
+						'LinkingMode' => ($same) ? 'current' : 'link',
+						'IsStable' => $check->getIsStable()
 					)));
 
 				}


### PR DESCRIPTION
This allows things like styling or highlighting of the currentl stable version when used in a project to make it more obvious that people should be using that documentation.