### PR TITLE
FIX for https://github.com/silverstripe/doc.silverstripe.org/issues/79

### DIFF
--- a/templates/Includes/DocumentationSidebar.ss
+++ b/templates/Includes/DocumentationSidebar.ss
@@ -3,9 +3,9 @@
 		$DocumentationSearchForm
 		
 		<ul class="nav">
-			<li><a href="$DocumentationBaseHref" class="top">Home</a></li>
 
 			<% loop Menu %>
+				<li><a href="$Link" class="top">Home</a></li>
 				<% if DefaultEntity %>
 					<% loop Children %>
 						<li class="$LinkingMode <% if Last %>last<% end_if %>">


### PR DESCRIPTION
This is a simple band-aid fix for https://github.com/silverstripe/doc.silverstripe.org/issues/79 but I am worried about the fact that the HOME link is now inside the <% loop Menu %>. If there is ever more than one item in this loop then the HOME link would appear multiple times. 

A better solution seems to be changing https://github.com/silverstripe/silverstripe-docsviewer/blob/master/code/controllers/DocumentationViewer.php#L674 but I couldn't quite see how to do that. Any suggestions ? 