### PR TITLE
FIX for https://github.com/silverstripe/doc.silverstripe.org/issues/79

### DIFF
--- a/templates/Includes/DocumentationSidebar.ss
+++ b/templates/Includes/DocumentationSidebar.ss
@@ -3,7 +3,7 @@
 		$DocumentationSearchForm
 		
 		<ul class="nav">
-			<li><a href="$DocumentationBaseHref" class="top">Home</a></li>
+			<li><a href="$Menu.First.Link" class="top">Home</a></li>
 
 			<% loop Menu %>
 				<% if DefaultEntity %>


### PR DESCRIPTION
Simple bit of sticky plaster to fix https://github.com/silverstripe/doc.silverstripe.org/issues/79.

Perhaps a better solution is to keep $DocumentationBaseRef and instead edit https://github.com/silverstripe/silverstripe-docsviewer/blob/master/code/controllers/DocumentationViewer.php#L674 ?

