### PR TITLE
ENHANCEMENT Config option to clear docsviewer requirements

### DIFF
--- a/code/controllers/DocumentationViewer.php
+++ b/code/controllers/DocumentationViewer.php
@@ -80,6 +80,13 @@ class DocumentationViewer extends Controller
     private static $edit_links = array();
 
     /**
+     * @var array map of modules to edit links.
+     * @see {@link getEditLink()}
+     */
+    private static $clear_requirements = false;
+
+
+    /**
      *
      */
     public function init()
@@ -89,21 +96,26 @@ class DocumentationViewer extends Controller
         if (!$this->canView()) {
             return Security::permissionFailure($this);
         }
-        Requirements::javascript('//use.typekit.net/emt4dhq.js');
-        Requirements::customScript('try{Typekit.load();}catch(e){}');
 
-        Requirements::javascript(THIRDPARTY_DIR .'/jquery/jquery.js');
-        Requirements::javascript('https://google-code-prettify.googlecode.com/svn/loader/run_prettify.js');
+        if(!$this->config()->clear_requirements) {
+            Requirements::javascript('//use.typekit.net/emt4dhq.js');
+            Requirements::customScript('try{Typekit.load();}catch(e){}');
 
-        Requirements::javascript(DOCSVIEWER_DIR .'/javascript/DocumentationViewer.js');
-        Requirements::combine_files('docs.css', array(
-            DOCSVIEWER_DIR .'/css/normalize.css',
-            DOCSVIEWER_DIR .'/css/utilities.css',
-            DOCSVIEWER_DIR .'/css/typography.css',
-            DOCSVIEWER_DIR .'/css/forms.css',
-            DOCSVIEWER_DIR .'/css/layout.css',
-            DOCSVIEWER_DIR .'/css/small.css'
-        ));
+            Requirements::javascript(THIRDPARTY_DIR . '/jquery/jquery.js');
+            Requirements::javascript('https://google-code-prettify.googlecode.com/svn/loader/run_prettify.js');
+
+            Requirements::javascript(DOCSVIEWER_DIR . '/javascript/DocumentationViewer.js');
+            Requirements::combine_files('docs.css', array(
+                DOCSVIEWER_DIR . '/css/normalize.css',
+                DOCSVIEWER_DIR . '/css/utilities.css',
+                DOCSVIEWER_DIR . '/css/typography.css',
+                DOCSVIEWER_DIR . '/css/forms.css',
+                DOCSVIEWER_DIR . '/css/layout.css',
+                DOCSVIEWER_DIR . '/css/small.css'
+            ));
+        }
+
+
     }
 
     /**

--- a/code/controllers/DocumentationViewer.php
+++ b/code/controllers/DocumentationViewer.php
@@ -80,8 +80,8 @@ class DocumentationViewer extends Controller
     private static $edit_links = array();
 
     /**
-     * @var array map of modules to edit links.
-     * @see {@link getEditLink()}
+     * @var boolean whether to clear the docsviewer requirements.
+     * @see {@link init()}
      */
     private static $clear_requirements = false;
 


### PR DESCRIPTION
 if you are integrating into another site for example... the requirements play havoc with existing styles. Using a blanket Requirements::clear removes all including those you actually want on your existing site.

This simple config option allows you to disable the included js and css so you can roll your own if need be.