### PR TITLE
FIX: Api shortcode issues

### DIFF
--- a/tests/DocumentationParserTest.php
+++ b/tests/DocumentationParserTest.php
@@ -323,11 +323,11 @@ HTML;
         );
 
         $this->assertContains(
-            '[link: api](http://api.silverstripe.org/search/lookup/?q=DataObject&amp;version=2.4&amp;module=documentationparsertest)',
+            '[link: api](http://api.silverstripe.org/search/lookup/?q=DataObject&version=2.4&module=documentationparsertest)',
             $result
         );
         $this->assertContains(
-            '[DataObject::$has_one](http://api.silverstripe.org/search/lookup/?q=DataObject::$has_one&amp;version=2.4&amp;module=documentationparsertest)',
+            '[DataObject::$has_one](http://api.silverstripe.org/search/lookup/?q=DataObject::$has_one&version=2.4&module=documentationparsertest)',
             $result
         );
     }


### PR DESCRIPTION
Fixes several issues. See the following for background:

silverstripe/silverstripe-docsviewer/pull/62
silverstripe/silverstripe-framework/issues/4002
silverstripe/silverstripe-docsviewer/issues/89
silverstripe/silverstripe-docsviewer/issues/37

The three main problems were:

(1) https://github.com/silverstripe/silverstripe-docsviewer/blob/master/code/DocumentationParser.php#L18 has two extra "amp;" in format string for api url

(2) the docs use "[ClassName->classMethod()]" but apigen requires that "ClassName::classMethod()" is passed in the url query. 

(3) https://github.com/silverstripe/silverstripe-docsviewer/blob/master/code/DocumentationParser.php#L277 and https://github.com/silverstripe/silverstripe-docsviewer/blob/master/code/DocumentationParser.php#L327 output "(%s)" but when "ClassName::classMethod()" is passed into "%s" there are two sets of parentheses and this confuses the markdown parser. This is avoided by directly outputting html. 