### PR TITLE
BUGFIX: Fixed issues related to windows filesystem using backslash instead of forward slash

### DIFF
--- a/code/DocumentationHelper.php
+++ b/code/DocumentationHelper.php
@@ -92,4 +92,20 @@ class DocumentationHelper
 
         return null;
     }
+
+    /**
+     * Helper function to normalize paths to unix style directory separators
+     * 
+     * @param string
+     * 
+     * @return string
+     */
+    public static function normalizePath($path)
+    {
+        if (DIRECTORY_SEPARATOR != '/') {
+            return str_replace(DIRECTORY_SEPARATOR, '/', $path);
+        }
+        
+        return $path;
+    }
 }

--- a/code/DocumentationManifest.php
+++ b/code/DocumentationManifest.php
@@ -145,7 +145,7 @@ class DocumentationManifest
                             'DocumentationEntity', $key
                         );
 
-                        $entity->setPath(Controller::join_links($path, $lang, '/'));
+                        $entity->setPath(DocumentationHelper::normalizePath(Controller::join_links($path, $lang, '/')));
                         $entity->setTitle($details['Title']);
                         $entity->setLanguage($lang);
                         $entity->setVersion($version);
@@ -168,7 +168,7 @@ class DocumentationManifest
 
     public function getRealPath($path)
     {
-        if (substr($path, 0, 1) != '/') {
+        if (!Director::is_absolute($path)) {
             $path = Controller::join_links(BASE_PATH, $path);
         }
 
@@ -201,7 +201,7 @@ class DocumentationManifest
                 continue;
             }
 
-            $dir = Controller::join_links(BASE_PATH, $entity);
+            $dir = DocumentationHelper::normalizePath(Controller::join_links(BASE_PATH, $entity));
 
             if (is_dir($dir)) {
                 // check to see if it has docs
@@ -406,7 +406,7 @@ class DocumentationManifest
         $this->pages[$link] = array(
             'title' => $page->getTitle(),
             'basename' => $basename,
-            'filepath' => $path,
+            'filepath' => DocumentationHelper::normalizePath($path),
             'type' => get_class($page),
             'entitypath' => $this->entity->getPath(),
             'summary' => $page->getSummary()
@@ -627,7 +627,7 @@ class DocumentationManifest
         $base = Config::inst()->get('DocumentationViewer', 'link_base');
         $entityPath = $this->normalizeUrl($entityPath);
         $recordPath = $this->normalizeUrl($recordPath);
-        $recordParts = explode(DIRECTORY_SEPARATOR, trim($recordPath, '/'));
+        $recordParts = explode('/', trim($recordPath, '/'));
         $currentRecordPath = end($recordParts);
         $depth = substr_count($entityPath, '/');
 
@@ -640,8 +640,8 @@ class DocumentationManifest
             }
 
             // only pull it up if it's one more level depth
-            if (substr_count($pagePath, DIRECTORY_SEPARATOR) == ($depth + 1)) {
-                $pagePathParts = explode(DIRECTORY_SEPARATOR, trim($pagePath, '/'));
+            if (substr_count($pagePath, '/') == ($depth + 1)) {
+                $pagePathParts = explode('/', trim($pagePath, '/'));
                 $currentPagePath = end($pagePathParts);
                 if ($currentPagePath == $currentRecordPath) {
                     $mode = 'current';

--- a/code/DocumentationParser.php
+++ b/code/DocumentationParser.php
@@ -440,12 +440,12 @@ class DocumentationParser
         
         // relative path (relative to module base folder), without the filename.
         // For "sapphire/en/current/topics/templates", this would be "templates"
-        $relativePath = dirname($page->getRelativePath());
+        $relativePath = DocumentationHelper::normalizePath(dirname($page->getRelativePath()));
 
         if (strpos($page->getRelativePath(), 'index.md')) {
             $relativeLink = $page->getRelativeLink();
         } else {
-            $relativeLink = dirname($page->getRelativeLink());
+            $relativeLink = DocumentationHelper::normalizePath(dirname($page->getRelativeLink()));
         }
 
         if ($relativePath == '.') {
@@ -457,7 +457,7 @@ class DocumentationParser
         }
         
         // file base link
-        $fileBaseLink = Director::makeRelative(dirname($page->getPath()));
+        $fileBaseLink = DocumentationHelper::normalizePath(Director::makeRelative(dirname($page->getPath())));
         
         if ($matches) {
             foreach ($matches[0] as $i => $match) {

--- a/code/models/DocumentationPage.php
+++ b/code/models/DocumentationPage.php
@@ -126,7 +126,7 @@ class DocumentationPage extends ViewableData
         if ($folder == $entity) {
             return $this->getEntity()->getTitle();
         } else {
-            $path = explode(DIRECTORY_SEPARATOR, trim($folder, DIRECTORY_SEPARATOR));
+            $path = explode('/', trim($folder, '/'));
             $folderName = array_pop($path);
         }
 


### PR DESCRIPTION
When using the module on windows DIRECTORY_SEPERATOR returns a backslash instead of a forward slash. This causes one primary issue, an infinite loop when getMenu() is called causing the memory limit to be reached. It also seems to cause issues doing other tasks like adjusting the links to relative files. Issue #70 is related to and fixed by this pull request.