### PR TITLE
BUGFIX: Fixed redirecting to strip extensions incorrectly redirecting

### DIFF
--- a/code/controllers/DocumentationViewer.php
+++ b/code/controllers/DocumentationViewer.php
@@ -166,7 +166,7 @@ class DocumentationViewer extends Controller
         if (DocumentationHelper::get_extension($url)) {
             $this->response = new SS_HTTPResponse();
             $this->response->redirect(
-                DocumentationHelper::trim_extension_off($url) .'/',
+                Director::absoluteURL(DocumentationHelper::trim_extension_off($url)) .'/',
                 301
             );
 

--- a/tests/DocumentationViewerTest.php
+++ b/tests/DocumentationViewerTest.php
@@ -217,4 +217,17 @@ class DocumentationViewerTest extends FunctionalTest
         $response = $this->get('dev/docs/all/');
         $this->assertEquals(404, $response->getStatusCode());
     }
+
+
+    public function testRedirectStripExtension()
+    {
+        // get url with .md extension
+        $response = $this->get('dev/docs/en/doc_test/3.0/tutorials.md');
+
+        // response should be a 301 redirect
+        $this->assertEquals(301, $response->getStatusCode());
+
+        // redirect should have been to the absolute url minus the .md extension
+        $this->assertEquals(Director::absoluteURL('dev/docs/en/doc_test/3.0/tutorials/'), $response->getHeader('Location'));
+    }
 }


### PR DESCRIPTION
With documentation in the default location (dev/docs/en/) it appears that in some cases the redirect from say dev/docs/en/my-module/my-doc-file.md to dev/docs/en/my-module/my-doc-file/ will end up being incorrectly redirected to dev/docs/my-module/dev/docs/my-module/my-doc-file/. This pull request simply changes the redirect to use an absolute url instead.