### PR TITLE
BUGFIX: Fixed duplicate Home links appearing

### DIFF
--- a/code/DocumentationManifest.php
+++ b/code/DocumentationManifest.php
@@ -64,6 +64,11 @@ class DocumentationManifest
     /**
      * @var boolean
      */
+    private $has_default_entity = false;
+
+    /**
+     * @var boolean
+     */
     private $automaticallyPopulated = false;
 
     /**
@@ -157,6 +162,9 @@ class DocumentationManifest
 
                         if (isset($details['DefaultEntity'])) {
                             $entity->setIsDefaultEntity($details['DefaultEntity']);
+                            if ($entity->getIsDefaultEntity()) {
+                                $this->has_default_entity = true;
+                            }
                         }
 
                         $this->registeredEntities->push($entity);
@@ -759,5 +767,14 @@ class DocumentationManifest
         asort($versions);
 
         return $versions;
+    }
+
+    /**
+     * Gets whether there is a default entity or not
+     * @return boolean
+     */
+    public function getHasDefaultEntity()
+    {
+        return $this->has_default_entity;
     }
 }

--- a/code/controllers/DocumentationViewer.php
+++ b/code/controllers/DocumentationViewer.php
@@ -709,4 +709,14 @@ class DocumentationViewer extends Controller
     {
         return Config::inst()->get('DocumentationViewer', 'link_base');
     }
+
+    /**
+     * Gets whether there is a default entity or not
+     * @return boolean
+     * @see DocumentationManifest::getHasDefaultEntity()
+     */
+    public function getHasDefaultEntity()
+    {
+        return $this->getManifest()->getHasDefaultEntity();
+    }
 }

--- a/templates/Includes/DocumentationSidebar.ss
+++ b/templates/Includes/DocumentationSidebar.ss
@@ -3,10 +3,14 @@
 		$DocumentationSearchForm
 		
 		<ul class="nav">
-
-			<% loop Menu %>
+			<% if not HasDefaultEntity %>
 				<li><a href="$Link" class="top">Home</a></li>
+			<% end_if %>
+			
+			<% loop Menu %>
 				<% if DefaultEntity %>
+					<li><a href="$Link" class="top">Home</a></li>
+					
 					<% loop Children %>
 						<li class="$LinkingMode <% if Last %>last<% end_if %>">
 							<a href="$Link" class="top">$Title</a>


### PR DESCRIPTION
Due to the location of the "Home" link for every module that the documentation covers it creates a duplicate link labeled "Home" this pull request moves the "Home" link outside the Menu loop which creates it only once with a link to the docs home.