### PR TITLE
BUGFIX: Links in the all pages view missing the documentation base link

### DIFF
--- a/code/controllers/DocumentationViewer.php
+++ b/code/controllers/DocumentationViewer.php
@@ -544,13 +544,14 @@ class DocumentationViewer extends Controller
     {
         $pages = $this->getManifest()->getPages();
         $output = new ArrayList();
+        $baseLink = $this->getDocumentationBaseHref();
 
         foreach ($pages as $url => $page) {
             $first = strtoupper(trim(substr($page['title'], 0, 1)));
 
             if ($first) {
                 $output->push(new ArrayData(array(
-                    'Link' => $url,
+                    'Link' => Controller::join_links($baseLink, $url),
                     'Title' => $page['title'],
                     'FirstLetter' => $first
                 )));


### PR DESCRIPTION
When viewing the "Documentation Index" links do not point inside of the base link for the documentation. For example links will appear as http://example.com/en/docviewer/ rather than the expected http://example.com/dev/docs/en/docviewer/ resulting in a 404 when clicked if the base link is anything other than the site root.