### PR TITLE
BUGFIX: Fixed issue generating image paths on windows

### DIFF
--- a/code/DocumentationHelper.php
+++ b/code/DocumentationHelper.php
@@ -108,4 +108,18 @@ class DocumentationHelper
         
         return $path;
     }
+
+    /**
+     * Helper function to make normalized paths relative
+     * 
+     * @param string
+     * 
+     * @return string
+     */
+    public static function relativePath($path)
+    {
+        $base = self::normalizePath(Director::baseFolder());
+        
+        return substr($path, strlen($base));
+    }
 }

--- a/code/DocumentationParser.php
+++ b/code/DocumentationParser.php
@@ -238,7 +238,7 @@ class DocumentationParser
                 }
                 
                 // Rewrite URL (relative or absolute)
-                $baselink = Director::makeRelative(
+                $baselink = DocumentationHelper::relativePath(
                     dirname($page->getPath())
                 );
 
@@ -457,7 +457,7 @@ class DocumentationParser
         }
         
         // file base link
-        $fileBaseLink = DocumentationHelper::normalizePath(Director::makeRelative(dirname($page->getPath())));
+        $fileBaseLink = DocumentationHelper::relativePath(DocumentationHelper::normalizePath(dirname($page->getPath())));
         
         if ($matches) {
             foreach ($matches[0] as $i => $match) {


### PR DESCRIPTION
Looks like I introduced a bug in 1556c77d2713732cce34dc1941b627116c7c707c on windows when the DocumentationParser tries to remap images and file links. Basically Director::makeRelative() checks before it makes the file system path relative since we're making the paths normalized it never matches the value of Director::baseFolder(). Which makes the path never made relative on windows. This pull request adds a new helper method to make these normalized paths relative using the same idea as what Director::makeRelative() would normally do.

I looked for another way to do this without regressing back to the infinite loop we had before 1556c77d2713732cce34dc1941b627116c7c707c  but I couldn't come up with away to make it work.