### PR TITLE
BUGFIX: Fixed issue next/previous page links missing the documentation base link

### DIFF
--- a/code/DocumentationManifest.php
+++ b/code/DocumentationManifest.php
@@ -534,7 +534,7 @@ class DocumentationManifest
         foreach ($this->getPages() as $url => $page) {
             if ($grabNext && strpos($page['filepath'], $entityBase) !== false) {
                 return new ArrayData(array(
-                    'Link' => $url,
+                    'Link' => Controller::join_links(Config::inst()->get('DocumentationViewer', 'link_base'), $url),
                     'Title' => $page['title']
                 ));
             }
@@ -543,7 +543,7 @@ class DocumentationManifest
                 $grabNext = true;
             } elseif (!$fallback && strpos($page['filepath'], $filepath) !== false) {
                 $fallback = new ArrayData(array(
-                    'Link' => $url,
+                    'Link' => Controller::join_links(Config::inst()->get('DocumentationViewer', 'link_base'), $url),
                     'Title' => $page['title'],
                     'Fallback' => true
                 ));
@@ -576,7 +576,7 @@ class DocumentationManifest
             if ($filepath == $page['filepath']) {
                 if ($previousUrl) {
                     return new ArrayData(array(
-                        'Link' => $previousUrl,
+                        'Link' => Controller::join_links(Config::inst()->get('DocumentationViewer', 'link_base'), $previousUrl),
                         'Title' => $previousPage['title']
                     ));
                 }


### PR DESCRIPTION
When viewing a documentation article the next/previous page buttons do not point inside of the base link for the documentation. For example links will appear as http://example.com/en/docviewer/ rather than the expected http://example.com/dev/docs/en/docviewer/ resulting in a 404 when clicked if the base link is anything other than the site root.