### PR TITLE
BUGFIX: Fixed file_get_contents warning when viewing a folder that has no index.md

### DIFF
--- a/code/models/DocumentationPage.php
+++ b/code/models/DocumentationPage.php
@@ -151,7 +151,7 @@ class DocumentationPage extends ViewableData
     public function getMarkdown($removeMetaData = false)
     {
         try {
-            if ($md = file_get_contents($this->getPath())) {
+            if (is_file($this->getPath()) && $md = file_get_contents($this->getPath())) {
                 $this->populateMetaDataFromText($md, $removeMetaData);
             
                 return $md;


### PR DESCRIPTION
This pull request fixes a warning generated from file_get_contents when viewing a folder that has no index.md caused by DocumentationPage.php trying to use file_get_contents() on a folder when attempting to get the Introduction.