### PR TITLE
BUGFIX: Fixed incorrectly formed page specific anchor links (fixes #104)

### DIFF
--- a/code/DocumentationParser.php
+++ b/code/DocumentationParser.php
@@ -482,6 +482,9 @@ class DocumentationParser
                         $fileBaseLink,
                         $url
                     );
+                } else if (preg_match('/^#/', $url)) {
+                    // for relative links begining with a hash use the current page link
+                    $relativeUrl = Controller::join_links($baselink, $page->getRelativeLink(), $url);
                 } else {
                     // Rewrite public URL
                     if (preg_match('/^\//', $url)) {

--- a/javascript/DocumentationViewer.js
+++ b/javascript/DocumentationViewer.js
@@ -120,7 +120,7 @@
 		 *
 		 * Automatically adds anchor links to headings that have IDs
 		 */
-		var url = window.location.href;
+		var url = window.location.href.replace(/#[a-zA-Z0-9\-\_]*/g, '');
 		
 		$("#content h1[id], #content h2[id], #content h3[id], #content h4[id], #content h5[id], #content h6[id]").each(function() {
 			var link = '<a class="heading-anchor-link" title="Link to this section" href="'+ url + '#' + $(this).attr('id') + '">&para;</a>';

--- a/tests/DocumentationParserTest.php
+++ b/tests/DocumentationParserTest.php
@@ -197,6 +197,16 @@ HTML;
             $result
         );
 
+        $this->assertContains(
+            '[link: with anchor](dev/docs/en/documentationparsertest/2.4/test/#anchor)',
+            $result
+        );
+
+        $this->assertContains(
+            '[link: relative anchor](dev/docs/en/documentationparsertest/2.4/test/#relative-anchor)',
+            $result
+        );
+
         $result = DocumentationParser::rewrite_relative_links(
             $this->subPage->getMarkdown(),
             $this->subPage

--- a/tests/docs/en/test.md
+++ b/tests/docs/en/test.md
@@ -8,6 +8,7 @@ test
 [link: subfolder page](subfolder/subpage)
 [link: with anchor](/test#anchor)
 [link: http](http://silverstripe.org)
+[link: relative anchor](#relative-anchor)
 
 `[Title](api:DataObject)`
 `[Title](api:DataObject::$defaults)`


### PR DESCRIPTION
This pull requests fixes the relative anchors on pages like https://docs.silverstripe.org/en/3.3/changelogs/3.2.0/ and resolves issue #104.