### PR TITLE
Added support for variable line endings.

### DIFF
--- a/code/DocumentationParser.php
+++ b/code/DocumentationParser.php
@@ -69,7 +69,7 @@ class DocumentationParser
         $end = false;
         $debug = false;
 
-        $lines = explode("\n", $md);
+        $lines = preg_split('/\\r\\n|\\r|\\n/', $md);
         $output = array();
 
         foreach ($lines as $i => $line) {
@@ -394,7 +394,7 @@ class DocumentationParser
             $headingText .= "-" . self::$heading_counts[$headingText];
         }
 
-        return sprintf("%s {#%s}", preg_replace('/\n/', '', $heading), self::generate_html_id($headingText));
+        return sprintf("%s {#%s}", preg_replace('/\\r\\n|\\r|\\n/', '', $heading), self::generate_html_id($headingText));
     }
     
     /**


### PR DESCRIPTION
This tweak fixes parsing of documents with Windows line endings. Currently these files lose most of their blank lines and end up with IDs on the line after headings, causing the Markdown parser to return some very odd results.

You can see an example of the current behaviour [here](https://www.cwp.govt.nz/developer-docs/en/1.3/how_tos/caching/).