### PR TITLE
Updated invalid url for syntax highligter

### DIFF
--- a/code/controllers/DocumentationViewer.php
+++ b/code/controllers/DocumentationViewer.php
@@ -102,7 +102,7 @@ class DocumentationViewer extends Controller
             Requirements::customScript('try{Typekit.load();}catch(e){}');
 
             Requirements::javascript(THIRDPARTY_DIR .'/jquery/jquery.js');
-            Requirements::javascript('https://google-code-prettify.googlecode.com/svn/loader/run_prettify.js');
+            Requirements::javascript('https://cdn.rawgit.com/google/code-prettify/master/loader/run_prettify.js');
 
             Requirements::javascript(DOCSVIEWER_DIR .'/javascript/DocumentationViewer.js');
             Requirements::combine_files('docs.css', array(


### PR DESCRIPTION
See https://code.google.com/archive/p/google-code-prettify and https://github.com/google/code-prettify

This affects doc.silverstripe.org so the live site will need to be updated.