### PR TITLE
FIX horizontal alignment shifts when vertical scroll bar appears

### DIFF
--- a/css/layout.css
+++ b/css/layout.css
@@ -5,6 +5,7 @@ html {
 	padding-bottom: 40px;
 	-webkit-font-smoothing: antialiased;
 	box-sizing: border-box;
+	overflow-y: scroll;
 }
 
 *, *:before, *:after {


### PR DESCRIPTION
Noticed problem when using docsviewer on a site I am developing. Common problem. Easy fix.

Quite visible if (i) a page's content fits within the browser window's height when the table of contents dropdown is closed but (ii) the content no longer fits vertically when the table of contents dropdown is opened. When the dropdown is opened, a vertical scroll bar appears in the browser and the page's horizontal alignment shifts by the scroll bar width.  

@frankmullenger FYI: I also noticed this in swipestripe docs :)