### PR TITLE
Newer parsedown requirement; PHP 7 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,21 +4,14 @@ sudo: false
 
 language: php
 
-dist: precise
-
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6
-  - 7.0
+  - 7.1
 
 env:
   - DB=MYSQL CORE_RELEASE=3
-
-matrix:
-  allow_failures:
-    - php: 7.0
 
 before_script:
   - composer self-update || true

--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,8 @@
     },
 	"require": {
         "silverstripe/framework": "~3.1",
-        "erusev/parsedown-extra": "0.2.2",
-        "erusev/parsedown": "~1.1.0",
+        "erusev/parsedown-extra": "~0.2",
+        "erusev/parsedown": "~1.1",
         "mnapoli/front-yaml": "^1.5"
     },
     "suggest": {


### PR DESCRIPTION
Dependency for parsedown increased to minor semver version ~1.1 . Reason: other modules that require parsedown as dependency need higher version of it.