### PR TITLE
NEW Adjust docs colours to be web accessible

### DIFF
--- a/css/highlight.css
+++ b/css/highlight.css
@@ -8,23 +8,23 @@ Customised for doc.silverstripe.org, see CUSTOM markers.
 .hljs {
   display: block;
   overflow-x: auto;
-  padding: 0.5em;
-  color: #333;
+  padding: 1.5em 1em;
+  color: #444;
   background: #f3f6f6; /* CUSTOM */
   border-radius: 3px; /* CUSTOM */
-  box-shadow: 0 1px 1px rgba(0,0,0,.125); /* CUSTOM */
+  box-shadow: 0 1px 3px rgba(0,0,0,.15); /* CUSTOM */
 }
 
 .hljs-comment,
 .hljs-quote {
-  color: #998;
+  color: #717171;
   font-style: italic;
 }
 
 .hljs-keyword,
 .hljs-selector-tag,
 .hljs-subst {
-  color: #333;
+  color: #444;
   font-weight: bold;
 }
 
@@ -33,12 +33,12 @@ Customised for doc.silverstripe.org, see CUSTOM markers.
 .hljs-variable,
 .hljs-template-variable,
 .hljs-tag .hljs-attr {
-  color: #008080;
+  color: #007e7e;
 }
 
 .hljs-string,
 .hljs-doctag {
-  color: #d14;
+  color: #ed135a;
 }
 
 .hljs-title,
@@ -67,7 +67,7 @@ Customised for doc.silverstripe.org, see CUSTOM markers.
 
 .hljs-regexp,
 .hljs-link {
-  color: #009926;
+  color: #008500;
 }
 
 .hljs-symbol,

--- a/css/layout.css
+++ b/css/layout.css
@@ -476,35 +476,26 @@ html {
     text-align: center;
 }
 
+.info,
 .notice,
 .note,
 .warningBox {
-    background: #FFFFAD;
+    background: #e6f5fc;
 }
 
 .warning,
 .alert {
-    background: #FF8480;
-    color:#fff;
-}
-
-.warning a,
-.alert a {
-    color:#fff;
-    text-decoration:underline;
+    background: #ffdcdb;
+    color: #586667;
 }
 
 .warning code,
 .alert code {
-    color:#666;
+    color: #666;
 }
 
 .hint {
-    background: #f4f4f4;
-}
-
-.info {
-    background: #CAF7FF;
+    background: #f0f4f4;
 }
 
 .warning p {

--- a/css/typography.css
+++ b/css/typography.css
@@ -164,7 +164,7 @@ h3 {
     font-size: 20px;
     line-height: 20px;
     margin: 30px 0 10px;
-    color: #181c1d;
+    color: #586667;
 }
 
 h4 {
@@ -332,7 +332,7 @@ table {
         border: 1px solid #d4d4d4;
         border-bottom-color: #bcbcbc;
         text-shadow: 0 1px 0 #fff;
-        color: #333;
+        color: #444;
         font-weight: bold;
         margin-bottom: 5px;
         text-decoration: none;


### PR DESCRIPTION
Resolves https://github.com/silverstripe/doc.silverstripe.org/issues/164
Reference #134 #139

After discussion with @clarkepaul we decided to keep the lighter code block colours due to being easier on the eye as a whole for the page. With the dark background they are easier to read individually but when viewing the page as a whole it is quite distracting with the ever changing background. This could be down to individual preference, but hopefully, this is still a step forward.