### PR TITLE
FIX Ensure first processed stable version is treated as canonical

### DIFF
--- a/code/DocumentationManifest.php
+++ b/code/DocumentationManifest.php
@@ -459,7 +459,12 @@ class DocumentationManifest
     {
         $fromLink = $this->stripLinkBase($from);
         $toLink = $this->stripLinkBase($to);
-        $this->redirects[$fromLink] = $toLink;
+
+        // If the redirect "from" is already registered with a "to", don't override it. This ensures
+        // that the first version processed is treated as the canonical version.
+        if (!isset($this->redirects[$fromLink])) {
+            $this->redirects[$fromLink] = $toLink;
+        }
     }
 
     /**


### PR DESCRIPTION
What currently happens is the manifest loops all versions and adds redirects for each version to handle versionless URLs to redirect to that version's equivalent, but will overwrite existing entries. Since 4 (in docs.silverstripe.org) is registered before 3, the result ends up with canonicals with 3 instead of 4 (desired).