### PR TITLE
FIX Remove image styles - revert to original

### DIFF
--- a/css/typography.css
+++ b/css/typography.css
@@ -210,8 +210,10 @@ h6 .heading-anchor-link {
 /*! images */
 img {
     max-width: 100%;
-    padding: 10px;
-    float: right;
+    border: 1px solid #ccc;
+    padding: 6px;
+    margin: 10px 0;
+    border-radius: 3px;
 }
 
 /*! code */


### PR DESCRIPTION
Sorry, this was my mistake, will create a separate P.R to address footer license image.

Fixes: https://github.com/silverstripe/doc.silverstripe.org/issues/171 and https://github.com/silverstripeltd/ssorg/issues/56