### PR TITLE
FIX: Ensure that canonical URLs don’t redirect elsewhere.

### DIFF
--- a/code/controllers/DocumentationViewer.php
+++ b/code/controllers/DocumentationViewer.php
@@ -588,10 +588,26 @@ class DocumentationViewer extends Controller implements PermissionProvider
      */
     public function getCanonicalUrl()
     {
-        if (!$this->getPage()) {
+        $page = $this->getPage();
+
+        if (!$page) {
             return '';
         }
-        return $this->getPage()->getCanonicalUrl();
+
+        // Build the basic canoncial URL, relative to link_base as is mapped in the manifest
+        $url = Controller::join_links(
+            $page->getEntity()->getLanguage(),
+            $page->getRelativeLink()
+        );
+
+        // If the canoncial URL is, in fact, a redirect, post that directly - redirecting canoncials are a bad thing.
+        // See https://github.com/silverstripe/doc.silverstripe.org/issues/181 for discussion
+        if ($potentialRedirect = $this->manifest->getRedirect($url)) {
+            $url = $potentialRedirect;
+        }
+
+        // Turn into an absolute URL
+        return Director::absoluteUrl(Controller::join_links(self::getDocumentationBaseHref(), $url));
     }
 
     /**

--- a/code/models/DocumentationPage.php
+++ b/code/models/DocumentationPage.php
@@ -270,6 +270,8 @@ class DocumentationPage extends ViewableData
 
     /**
      * Determine and set the canonical URL for the given record, for example: dev/docs/en/Path/To/Document
+     *
+     * @deprecated 2.1.0 This method is no longer used.
      */
     public function populateCanonicalUrl()
     {
@@ -371,6 +373,7 @@ class DocumentationPage extends ViewableData
     /**
      * Set the canonical URL to use for this page
      *
+     * @deprecated 2.1.0 This method is no longer used.
      * @param string $canonicalUrl
      * @return $this
      */
@@ -386,6 +389,7 @@ class DocumentationPage extends ViewableData
      * Get the canonical URL to use for this page. Will trigger discovery
      * via {@link DocumentationPage::populateCanonicalUrl()} if none is already set.
      *
+     * @deprecated 2.1.0 This method is no longer used.
      * @return string
      */
     public function getCanonicalUrl()

--- a/code/models/DocumentationPage.php
+++ b/code/models/DocumentationPage.php
@@ -376,6 +376,8 @@ class DocumentationPage extends ViewableData
      */
     public function setCanonicalUrl($canonicalUrl)
     {
+        user_error("DocumentationPage::setCanonicalUrl() is deprecated; it won't affect DocumentationViewer", E_USER_WARNING);
+
         $this->canonicalUrl = $canonicalUrl;
         return $this;
     }
@@ -388,6 +390,11 @@ class DocumentationPage extends ViewableData
      */
     public function getCanonicalUrl()
     {
+        user_error(
+            "DocumentationPage::getCanonicalUrl() is deprecated; use DocumentationViewer::getCanonicalUrl() instead.",
+            E_USER_WARNING
+        );
+
         if (!$this->canonicalUrl) {
             $this->populateCanonicalUrl();
         }

--- a/tests/DocumentationPageTest.php
+++ b/tests/DocumentationPageTest.php
@@ -90,22 +90,4 @@ class DocumentationPageTest extends SapphireTest
 
         $this->assertEquals('Sort - Doctest', $page->getBreadcrumbTitle());
     }
-
-    public function testGetCanonicalUrl()
-    {
-        $page = new DocumentationPage(
-            $this->entity,
-            'file.md',
-            DOCSVIEWER_PATH . '/tests/docs/en/test/file.md'
-        );
-
-        $this->assertContains(
-            'dev/docs/en/test/file/',
-            $page->getCanonicalUrl(),
-            'Canonical URL is determined, set and returned'
-        );
-
-        $page->setCanonicalUrl('some-other-url');
-        $this->assertSame('some-other-url', $page->getCanonicalUrl(), 'Canonical URL can be adjusted via public API');
-    }
 }


### PR DESCRIPTION
Redirecting canonical URLs violate HTTP rules and break some search 
spiders including Swiftype.

As part of this change, DocumentationPage loses responsibility for
calculating canonical URLs. I’ve opted to leave the methods in there
but they will throw warnings.

Fixes https://github.com/silverstripe/doc.silverstripe.org/issues/181

---

To do:

 * [x] Add PHPDoc deprecation notice as well as the error