### PR TITLE
jQuery 3 compatibility.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,26 @@
-# See https://github.com/silverstripe-labs/silverstripe-travis-support for setup details
+# See https://github.com/silverstripe/silverstripe-travis-support for setup details
 
-sudo: false
+dist: trusty
 
 language: php
 
-php:
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7.1
-
 env:
-  - DB=MYSQL CORE_RELEASE=3
+  - DB=MYSQL CORE_RELEASE=3.7
+
+matrix:
+  include:
+    - php: '7.1'
+      env: DB=MYSQL CORE_RELEASE=3.7
+    - php: '7.2'
+      env: DB=MYSQL CORE_RELEASE=3.7
+    - php: '7.3'
+      env: DB=MYSQL CORE_RELEASE=3.7
 
 before_script:
   - composer self-update || true
-  - git clone git://github.com/silverstripe-labs/silverstripe-travis-support.git ~/travis-support
+  - git clone git://github.com/silverstripe/silverstripe-travis-support.git ~/travis-support
   - php ~/travis-support/travis_setup.php --source `pwd` --target ~/builds/ss
   - cd ~/builds/ss
-  - composer install
 
 script:
   - vendor/bin/phpunit docsviewer/tests

--- a/javascript/DocumentationViewer.js
+++ b/javascript/DocumentationViewer.js
@@ -55,7 +55,7 @@
                 }
             };
 
-            $(window).load(updateTables);
+            $(window).on('load', updateTables);
             $(window).on(
                 "redraw",function() {
                     switched = false;


### PR DESCRIPTION
From jQuery 1.7.2 docs:
> This method is a shortcut for `.on( "load", handler )`
https://api.jquery.com/load-event/#load-handler

This method was deprecated in jQuery 1.8, getting in the way of jQuery 3 upgrade.

This is a backwards compatible change and can be merged into master and downmerged to v2 because:

* This module requires SS Framework 3, regardless of branch.
* SS Framework 3 bundles jQuery 1.7.2.
* 1.7.2 supports the `on` handler.